### PR TITLE
Masweetman patch fix icon

### DIFF
--- a/assets/stylesheets/style.css
+++ b/assets/stylesheets/style.css
@@ -1,5 +1,6 @@
 #admin-menu a.custom-workflows {
     background-image: url(../../../images/ticket_go.png);
+    background-repeat: no-repeat;
 }
 
 #tab-content-custom_workflows .disabled {

--- a/assets/stylesheets/style.css
+++ b/assets/stylesheets/style.css
@@ -1,6 +1,8 @@
 #admin-menu a.custom-workflows {
     background-image: url(../../../images/ticket_go.png);
+    background-position: 0% 50%;
     background-repeat: no-repeat;
+    padding-left: 20px;
 }
 
 #tab-content-custom_workflows .disabled {


### PR DESCRIPTION
Settings menu item doesn't use icon style, so the background image repeats and isn't spaced the same as the rest of the icons. Update to use the icon style or replicate the icon style in the custom-workflows menu item style.