### PR TITLE
compatibility with admin icon to redmine 3.4.X

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,8 @@ Redmine::Plugin.register :redmine_custom_workflows do
   url 'http://www.redmine.org/plugins/custom-workflows'
 
   menu :admin_menu, :custom_workflows, {:controller => 'custom_workflows', :action => 'index'},
-       :if => Proc.new { User.current.admin? }, :caption => :label_custom_workflow_plural
+       :if => Proc.new { User.current.admin? }, :caption => :label_custom_workflow_plural,
+       :html => {:class => 'icon icon-custom-workflows'}
 
   permission :manage_project_workflow, {}, :require => :member
 end


### PR DESCRIPTION
missing :html => {:class => 'icon icon-custom-workflows'} on menu item

maybe overrides pr #86