### PR TITLE
Viewing wiki version raises a error

### DIFF
--- a/lib/redmine_custom_workflows/patches/controllers/wiki_controller_patch.rb
+++ b/lib/redmine_custom_workflows/patches/controllers/wiki_controller_patch.rb
@@ -73,7 +73,9 @@ module RedmineCustomWorkflows
           elsif @page
             objects = [@page]
           end
-          if @content
+          # @content either WikiContent or WikiContentVersion
+          # but plugin does not patch nor work with WikiContentVersion
+          if @content.is_a? WikiContent
             objects ||= []
             objects << @content
           end


### PR DESCRIPTION
Viewing a specific version of wiki is ending up with exception. Open something like `/projects/ecookbook/wiki/CookBook_documentation/2` to reproduce.

Stacktrace:
```ruby
NoMethodError: undefined method `custom_workflow_messages' for #<WikiContentVersion:0x00007f7b4701af80>
    plugins/redmine_custom_workflows/lib/redmine_custom_workflows/patches/controllers/wiki_controller_patch.rb:54:in `block in display_custom_workflow_messages'
    plugins/redmine_custom_workflows/lib/redmine_custom_workflows/patches/controllers/wiki_controller_patch.rb:53:in `each'
    plugins/redmine_custom_workflows/lib/redmine_custom_workflows/patches/controllers/wiki_controller_patch.rb:53:in `display_custom_workflow_messages'
```
This is happens because `@content` in wiki controller patch might be assigned to `WikiContentVersion` which is not supported by plugin.
I suggest to ignore `WikiContentVersion` in that case since it's not possible to define custom workflows for it.