### PR TITLE
Add Member as a observable object.

### DIFF
--- a/app/models/custom_workflow.rb
+++ b/app/models/custom_workflow.rb
@@ -21,12 +21,12 @@
 
 # Custom workflow model
 class CustomWorkflow < ApplicationRecord
-  OBSERVABLES = %i[issue issue_relation issue_attachments user attachment group group_users project project_attachments
+  OBSERVABLES = %i[issue issue_relation issue_attachments user member attachment group group_users project project_attachments
                    wiki_content wiki_page_attachments time_entry version shared].freeze
   PROJECT_OBSERVABLES = %i[issue issue_attachments project project_attachments wiki_content wiki_page_attachments
                            time_entry version].freeze
   COLLECTION_OBSERVABLES = %i[group_users issue_attachments project_attachments wiki_page_attachments].freeze
-  SINGLE_OBSERVABLES = %i[issue issue_relation user group attachment project wiki_content time_entry version].freeze
+  SINGLE_OBSERVABLES = %i[issue issue_relation user member group attachment project wiki_content time_entry version].freeze
 
   acts_as_list
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,8 @@ en:
     e.g. functions and classes needed by other workflows
   text_custom_workflow_user_code_note: Scripts are executed in the context of User object when user object changes
     (destroys). Use methods and properties of the user directly (or through `self`)
+  text_custom_workflow_member_code_note: Scripts are executed in the context of Member object when member object changes
+    (destroys). Use methods and properties of the @member directly (or through `self`)
   text_custom_workflow_group_code_note: Scripts are executed in the context of Group object when group object changes
     (destroys). Use methods and properties of the group directly (or through `self`)
   text_custom_workflow_group_users_code_note: These scripts are executed when user being added to group/removed from
@@ -115,6 +117,7 @@ en:
   custom_workflow_observable_issue_attachments: Issue Attachments
   custom_workflow_observable_group: Group
   custom_workflow_observable_user: User
+  custom_workflow_observable_member: Member
   custom_workflow_observable_attachment: Attachment
   custom_workflow_observable_project: Project
   custom_workflow_observable_project_attachments: Project Attachments / Files

--- a/lib/redmine_custom_workflows/patches/models/member_patch.rb
+++ b/lib/redmine_custom_workflows/patches/models/member_patch.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Redmine plugin for Custom Workflows
+#
+# Copyright © 2015-19 Anton Argirov
+# Copyright © 2019-23 Karel Pičman <karel.picman@kontron.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+module RedmineCustomWorkflows
+  module Patches
+    module Models
+      # Member model patch
+      module MemberPatch
+        def custom_workflow_messages
+          @custom_workflow_messages ||= {}
+        end
+
+        def custom_workflow_env
+          @custom_workflow_env ||= {}
+        end
+
+        def self.prepended(base)
+          base.class_eval do
+            before_save :before_save_custom_workflows
+            after_save :after_save_custom_workflows
+            before_destroy :before_destroy_custom_workflows
+            after_destroy :after_destroy_custom_workflows
+          end
+        end
+
+        def before_save_custom_workflows
+          @member = self
+          @saved_attributes = attributes.dup
+          CustomWorkflow.run_shared_code self
+          CustomWorkflow.run_custom_workflows :member, self, :before_save
+          throw :abort if errors.any?
+
+          errors.empty? && (@saved_attributes == attributes || valid?)
+        ensure
+          @saved_attributes = nil
+        end
+
+        def after_save_custom_workflows
+          CustomWorkflow.run_custom_workflows :member, self, :after_save
+        end
+
+        def before_destroy_custom_workflows
+          res = CustomWorkflow.run_custom_workflows :member, self, :before_destroy
+          throw :abort if res == false
+        end
+
+        def after_destroy_custom_workflows
+          CustomWorkflow.run_custom_workflows :member, self, :after_destroy
+        end
+      end
+    end
+  end
+end
+
+# Apply the patch
+if Redmine::Plugin.installed?('easy_extensions')
+  RedmineExtensions::PatchManager.register_model_patch 'Member', 'RedmineCustomWorkflows::Patches::Models::MemberPatch'
+else
+  User.prepend RedmineCustomWorkflows::Patches::Models::MemberPatch
+end


### PR DESCRIPTION
Our client's workflow required changes based on adding users to projects in specific roles so here is a simple patch that enables monitoring Member as an observable object.